### PR TITLE
[add] Support Python 3.10

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python 3.5
       uses: actions/setup-python@v2
       with:
-        python-version: 3.5
+        python-version: "3.5"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: "3.7"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -56,7 +56,26 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.9"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python3 setup.py install
+    - name: Test with pytest
+      run: |
+        pytest -vv
+
+  test-py310:
+    runs-on: ubuntu-latest
+    needs: test-py39
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests
 beautifulsoup4
 typing; python_version<"3.5" # for backward compatibility
 pyuseragents
-inquirer==2.8.0
+inquirer>=2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests
 beautifulsoup4
 typing; python_version<"3.5" # for backward compatibility
 pyuseragents
-inquirer
+inquirer==2.8.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url="https://github.com/Animenosekai/translate",
     download_url="https://github.com/Animenosekai/translate/archive/v2.2.tar.gz",
     keywords=['python', 'translate', 'translation', 'google-translate', 'yandex-translate', 'bing-translate', 'reverso', 'transliteration', 'detect-language', 'text-to-speech', 'deepl', 'language'],
-    install_requires=['requests', 'beautifulsoup4', 'typing; python_version<"3.5"', 'pyuseragents', 'inquirer'],
+    install_requires=['requests', 'beautifulsoup4', 'typing; python_version<"3.5"', 'pyuseragents', 'inquirer>=2.8.0'],
     classifiers=['Development Status :: 5 - Production/Stable', 'License :: OSI Approved :: GNU General Public License v3 (GPLv3)', 'Programming Language :: Python :: 3', 'Programming Language :: Python :: 3.2', 'Programming Language :: Python :: 3.3', 'Programming Language :: Python :: 3.4', 'Programming Language :: Python :: 3.5', 'Programming Language :: Python :: 3.6', 'Programming Language :: Python :: 3.7', 'Programming Language :: Python :: 3.8', 'Programming Language :: Python :: 3.9'],
     long_description=readme_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
In the inquirer library, which is used to work CLI translatepy, there is a bug because of which on Python 3.10 it does not work. Fixed in inquirer 2.8.0. For more information see this: https://github.com/magmax/python-inquirer/pull/123