### PR TITLE
[fix] Error when using deepl for language zh.

### DIFF
--- a/translatepy/translators/deepl.py
+++ b/translatepy/translators/deepl.py
@@ -270,7 +270,7 @@ class DeeplTranslate(BaseTranslator):
 
     def _language_normalize(self, language):
         if language.id == "zho":
-            return "zh"
+            return "ZH"
         return language.alpha2.upper()
 
     def _language_denormalize(self, language_code):


### PR DESCRIPTION
Fix error "translatepy.exceptions.UnsupportedLanguage: The language zh is not supported by DeepL" when translate using deepl and language zh(Chinese).
The 'zh' return value should be upper case 'ZH'.

Code for testing:
```python
from translatepy.translators.deepl import (DeeplTranslate, DeeplTranslateException)
t = DeeplTranslate()
res = t.translate("Hello", "zh", "en")
```