### PR TITLE
[fix] More type check / More Bing auth token parse attempts /Separating server dependencies

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,0 +1,3 @@
+nasse @ git+https://github.com/Animenosekai/nasse.git # the latest 'main' branch version
+jinja2<3.1.0
+itsdangerous==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,3 @@ beautifulsoup4
 typing; python_version<"3.5" # for backward compatibility
 pyuseragents
 inquirer>=2.8.0
-
-
-# server
-git+https://github.com/Animenosekai/nasse # the latest 'main' branch version
-jinja2<3.1.0
-itsdangerous==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,14 @@ from os import path
 
 from setuptools import setup
 
-with open(path.join(path.abspath(path.dirname(__file__)), 'README.md'), encoding='utf-8') as f:
+with open(path.join(path.abspath(path.dirname(__file__)), "README.md"), encoding="utf-8") as f:
     readme_description = f.read()
+
+
+def read_requirements(filename):
+    with open(filename, "r", encoding="utf-8") as fp:
+        return fp.read().strip().splitlines()
+
 
 setup(
     name="translatepy",
@@ -15,19 +21,41 @@ setup(
     author_email="niichannomail@gmail.com",
     url="https://github.com/Animenosekai/translate",
     download_url="https://github.com/Animenosekai/translate/archive/v2.4.tar.gz",
-    keywords=['python', 'translate', 'translation', 'google-translate', 'yandex-translate', 'bing-translate', 'reverso', 'transliteration', 'detect-language', 'text-to-speech', 'deepl', 'language'],
-    install_requires=['requests', 'safeIO>=1.2', 'beautifulsoup4', 'typing; python_version<"3.5"', 'pyuseragents', 'inquirer>=2.8.0'],
-    classifiers=['Development Status :: 5 - Production/Stable', 'License :: OSI Approved :: GNU General Public License v3 (GPLv3)', 'Programming Language :: Python :: 3', 'Programming Language :: Python :: 3.2', 'Programming Language :: Python :: 3.3', 'Programming Language :: Python :: 3.4', 'Programming Language :: Python :: 3.5', 'Programming Language :: Python :: 3.6', 'Programming Language :: Python :: 3.7', 'Programming Language :: Python :: 3.8', 'Programming Language :: Python :: 3.9'],
+    keywords=[
+        "python",
+        "translate",
+        "translation",
+        "google-translate",
+        "yandex-translate",
+        "bing-translate",
+        "reverso",
+        "transliteration",
+        "detect-language",
+        "text-to-speech",
+        "deepl",
+        "language",
+    ],
+    install_requires=read_requirements("requirements.txt"),
+    extras_require={"server": read_requirements("requirements-server.txt")},
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.2",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
     long_description=readme_description,
     long_description_content_type="text/markdown",
     include_package_data=True,
-    python_requires='>=3.2, <4',
-    entry_points={
-        'console_scripts': [
-            'translatepy = translatepy.__main__:main'
-        ]
-    },
+    python_requires=">=3.2, <4",
+    entry_points={"console_scripts": ["translatepy = translatepy.__main__:main"]},
     package_data={
-        'translatepy': ['LICENSE'],
+        "translatepy": ["LICENSE"],
     },
 )

--- a/translatepy/translators/base.py
+++ b/translatepy/translators/base.py
@@ -502,6 +502,9 @@ class BaseTranslator(ABC):
         if gender not in {"male", "female"}:
             raise ParameterValueError("Gender {gender} not supported. Supported genders: male, female".format(gender=gender))
 
+        if not isinstance(speed, int):
+            raise ParameterTypeError("Parameter 'speed' must be a string, {} was given".format(type(speed).__name__))
+
         # Build cache key
         _cache_key = str({"t": text, "sp": speed, "s": source_code, "g": gender})
 
@@ -554,6 +557,8 @@ class BaseTranslator(ABC):
         """
         if isinstance(language, Language):
             result = language
+        elif not isinstance(language, str):
+            raise ParameterTypeError("Parameter 'language' must be a string, {} was given".format(type(language).__name__))
         else:
             result = Language(language)
 

--- a/translatepy/translators/base.py
+++ b/translatepy/translators/base.py
@@ -503,7 +503,7 @@ class BaseTranslator(ABC):
             raise ParameterValueError("Gender {gender} not supported. Supported genders: male, female".format(gender=gender))
 
         if not isinstance(speed, int):
-            raise ParameterTypeError("Parameter 'speed' must be a string, {} was given".format(type(speed).__name__))
+            raise ParameterTypeError("Parameter 'speed' must be an integer, {} was given".format(type(speed).__name__))
 
         # Build cache key
         _cache_key = str({"t": text, "sp": speed, "s": source_code, "g": gender})

--- a/translatepy/translators/bing.py
+++ b/translatepy/translators/bing.py
@@ -72,13 +72,18 @@ class BingSessionManager():
             self._parse_authorization_data()
 
     def _parse_authorization_data(self):
-        _request = self.session.get("https://www.bing.com/translator")
-        _page = _request.text
-        _parsed_IG = re.findall('IG:"(.*?)"', _page)
-        _parsed_IID = re.findall('data-iid="(.*?)"', _page)
-        _parsed_helper_info = re.findall("params_RichTranslateHelper = (.*?);", _page)
+        for _ in range(3):
+            _request = self.session.get("https://www.bing.com/translator")
+            _page = _request.text
+            _parsed_IG = re.findall('IG:"(.*?)"', _page)
+            _parsed_IID = re.findall('data-iid="(.*?)"', _page)
+            _parsed_helper_info = re.findall("params_RichTranslateHelper = (.*?);", _page)
 
-        if not _parsed_helper_info:
+            if not _parsed_helper_info:
+                continue
+
+            break
+        else:
             raise BingTranslateException(message="Can't parse the authorization data, try again later or use MicrosoftTranslate")
 
         _normalized_key = json.loads(_parsed_helper_info[0])[0]


### PR DESCRIPTION
- Bing Translator is now more usable, tests will not crash because of it (UPD: no, lmao)
- More type check for `language` and `speed` parameters
- The dependencies required for the server have been separated into a separate file, and by default these dependencies will not be installed. In order to install, need execute `pip3 install translatepy[server]`