### PR TITLE
Text splitting: DeepL Text Split on white space character

### DIFF
--- a/translatepy/translators/deepl.py
+++ b/translatepy/translators/deepl.py
@@ -19,7 +19,7 @@ from translatepy.translators.base import BaseTranslator, BaseTranslateException
 from translatepy.utils.annotations import Tuple, List
 from translatepy.utils.request import Request
 
-SENTENCES_SPLITTING_REGEX = compile('(?<=[.!:?]) +')
+SENTENCES_SPLITTING_REGEX = compile('(?<=[.!:?])\s+')
 
 
 class DeeplTranslateException(BaseTranslateException):


### PR DESCRIPTION
Existing text splitting regex not splitting text on new line or tab, only space character. Here `\s` will match all the white space character such as new line, tab and space.
Closes: https://github.com/Animenosekai/translate/issues/82